### PR TITLE
Openx: Pass through imp.ext.gpid, data and skadn

### DIFF
--- a/src/main/java/org/prebid/server/bidder/openx/proto/OpenxImpExt.java
+++ b/src/main/java/org/prebid/server/bidder/openx/proto/OpenxImpExt.java
@@ -3,13 +3,16 @@ package org.prebid.server.bidder.openx.proto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 import org.prebid.server.proto.openrtb.ext.request.ExtImpAuctionEnvironment;
 
 import java.util.Map;
 
-@AllArgsConstructor(staticName = "of")
+/**
+ * Defines bidrequest.imp.ext for outgoing requests from OpenX adapter
+ */
+@Builder(toBuilder = true)
 @Value
 public class OpenxImpExt {
 
@@ -19,4 +22,10 @@ public class OpenxImpExt {
     @JsonProperty("ae")
     @JsonInclude(value = JsonInclude.Include.NON_DEFAULT)
     ExtImpAuctionEnvironment auctionEnvironment;
+
+    String gpid;
+
+    JsonNode skadn;
+
+    JsonNode data;
 }

--- a/src/test/resources/org/prebid/server/it/openrtb2/openx/test-auction-openx-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/openx/test-auction-openx-request.json
@@ -19,6 +19,13 @@
               "bar2"
             ]
           }
+        },
+        "gpid": "gpidvalue",
+        "data": {
+          "pbadslot": "adslotvalue"
+        },
+        "skadn": {
+          "version": "2.0"
         }
       }
     }

--- a/src/test/resources/org/prebid/server/it/openrtb2/openx/test-openx-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/openx/test-openx-bid-request.json
@@ -17,6 +17,13 @@
             "bar1",
             "bar2"
           ]
+        },
+        "gpid": "gpidvalue",
+        "data": {
+          "pbadslot": "adslotvalue"
+        },
+        "skadn": {
+          "version": "2.0"
         }
       }
     }


### PR DESCRIPTION
pass imp.ext.gpid, imp.ext.data and imp.ext.skadn
not passing all of imp.ext because none of the other adapters do this, and I don't want to hold up the fix over it for now.