### PR TITLE
Openx: Pass through imp.ext wholesale except prebid, bidder

### DIFF
--- a/src/main/java/org/prebid/server/bidder/openx/proto/OpenxImpExt.java
+++ b/src/main/java/org/prebid/server/bidder/openx/proto/OpenxImpExt.java
@@ -1,22 +1,24 @@
 package org.prebid.server.bidder.openx.proto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import lombok.Value;
-import org.prebid.server.proto.openrtb.ext.request.ExtImpAuctionEnvironment;
+import org.prebid.server.proto.openrtb.ext.FlexibleExtension;
 
 import java.util.Map;
 
-@AllArgsConstructor(staticName = "of")
+/**
+ * Defines bidrequest.imp.ext for outgoing requests from OpenX adapter
+ */
+@Builder(toBuilder = true)
 @Value
-public class OpenxImpExt {
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class OpenxImpExt extends FlexibleExtension {
 
     @JsonProperty("customParams")
     Map<String, JsonNode> customParams;
-
-    @JsonProperty("ae")
-    @JsonInclude(value = JsonInclude.Include.NON_DEFAULT)
-    ExtImpAuctionEnvironment auctionEnvironment;
 }

--- a/src/main/resources/bidder-config/resetdigital.yaml
+++ b/src/main/resources/bidder-config/resetdigital.yaml
@@ -12,7 +12,7 @@ adapters:
         - video
         - audio
       supported-vendors:
-      vendor-id: 0
+      vendor-id: 1162
     usersync:
       cookie-family-name: resetdigital
       redirect:

--- a/src/test/resources/org/prebid/server/it/openrtb2/openx/test-auction-openx-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/openx/test-auction-openx-request.json
@@ -19,6 +19,13 @@
               "bar2"
             ]
           }
+        },
+        "gpid": "gpidvalue",
+        "data": {
+          "pbadslot": "adslotvalue"
+        },
+        "skadn": {
+          "version": "2.0"
         }
       }
     }

--- a/src/test/resources/org/prebid/server/it/openrtb2/openx/test-openx-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/openx/test-openx-bid-request.json
@@ -17,7 +17,15 @@
             "bar1",
             "bar2"
           ]
-        }
+        },
+        "gpid": "gpidvalue",
+        "data": {
+          "pbadslot": "adslotvalue"
+        },
+        "skadn": {
+          "version": "2.0"
+        },
+        "tid" : "${json-unit.any-string}"
       }
     }
   ],


### PR DESCRIPTION
Alternative to #2, pass all of `imp.ext` except `prebid` and `bidder`, merged with `customParameters` from `imp.ext.bidder`